### PR TITLE
fix(lib/huginn_bigcommerce_product_agent): make sure meta_fields are …

### DIFF
--- a/lib/huginn_bigcommerce_product_agent/bigcommerce_product_agent.rb
+++ b/lib/huginn_bigcommerce_product_agent/bigcommerce_product_agent.rb
@@ -138,16 +138,19 @@ module Agents
                 # ##############################
                 upsert_result = upsert_product(wrapper_sku, product, bc_product, is_digital)
                 bc_product = upsert_result[:product]
-                bc_products[wrapper_sku] = bc_product
-                product_id = bc_products[wrapper_sku]['id']
 
                 # clean up custom/meta fields. there are not batch operations so we might as well do them here.
                 custom_fields_delete = upsert_result[:custom_fields_delete].select {|field| field['name'] != 'related_product_id'}
                 clean_up_custom_fields(custom_fields_delete)
-                update_meta_fields(
+                meta_fields = update_meta_fields(
                     upsert_result[:meta_fields_upsert],
                     upsert_result[:meta_fields_delete],
                 )
+
+                bc_product['meta_fields'] = meta_fields
+
+                bc_products[wrapper_sku] = bc_product
+                product_id = bc_products[wrapper_sku]['id']
 
                 # ##############################
                 # 2. upsert option & option_values
@@ -233,6 +236,8 @@ module Agents
             # emit events
             # ##############################
             if bc_physical
+                Rails.logger.info("waldo the physical")
+                Rails.logger.info(bc_physical.inspect)
                 create_event payload: {
                     product: bc_physical
                 }

--- a/lib/huginn_bigcommerce_product_agent/bigcommerce_product_agent.rb
+++ b/lib/huginn_bigcommerce_product_agent/bigcommerce_product_agent.rb
@@ -236,8 +236,6 @@ module Agents
             # emit events
             # ##############################
             if bc_physical
-                Rails.logger.info("waldo the physical")
-                Rails.logger.info(bc_physical.inspect)
                 create_event payload: {
                     product: bc_physical
                 }


### PR DESCRIPTION
…being passed into new event

These changes move where the meta data is being cleaned and then makes sure the meta_data is being
passed through into the events. Along with this the javascript in the next agent needs to be
updated.

https://trello.com/c/k17Snkwk/184-usbat-see-editorial-reviews