### PR TITLE
feat(meta_field.rb, product_option.rb): log errors in delete meta-field and create product-option

### DIFF
--- a/lib/client/meta_field.rb
+++ b/lib/client/meta_field.rb
@@ -42,7 +42,11 @@ module BigcommerceProductAgent
             end
 
             def delete(product_id, meta_field_id)
-                client.delete(uri(product_id: product_id, meta_field_id: meta_field_id))
+                begin
+                    client.delete(uri(product_id: product_id, meta_field_id: meta_field_id))
+                rescue Faraday::Error::ClientError => e
+                    raise e, "\n#{e.message}\nFailed to delete meta_field with id = #{meta_field_id}\nfor product with id = #{product_id}\n", e.backtrace
+                end
             end
         end
     end

--- a/lib/client/product_option.rb
+++ b/lib/client/product_option.rb
@@ -33,8 +33,12 @@ module BigcommerceProductAgent
             end
 
             def create(product_id, option)
-                response = client.post(uri(product_id: product_id), option.to_json)
-                return response.body['data']
+                begin
+                    response = client.post(uri(product_id: product_id), option.to_json)
+                    return response.body['data']
+                rescue Faraday::Error::ClientError => e
+                    raise e, "\n#{e.message}\nFailed to upsert product_option = #{option.to_json}\nfor product with id = #{product_id}\n", e.backtrace
+                end
             end
         end
     end


### PR DESCRIPTION
A couple of products are still causing bugs here in product sync, and we still don't know why or even which products. This
should print their ids so we can figure out why they're causing errors