### PR TITLE
feat(bigcommerce_product_agent,product_mapper): Allow product deletion

### DIFF
--- a/lib/client/product.rb
+++ b/lib/client/product.rb
@@ -55,6 +55,13 @@ module BigcommerceProductAgent
                 map
             end
 
+            def disable(productId)
+              upsert({ id: productId, is_visible: false })
+            end
+
+            def enable(productId)
+              upsert({ id: productId, is_visible: true })
+            end
         end
     end
 end

--- a/lib/mapper/product_mapper.rb
+++ b/lib/mapper/product_mapper.rb
@@ -63,7 +63,7 @@ module BigcommerceProductAgent
                 variant = self.get_variant_by_sku(sku, product)
                 payload = self.map(product, variant, additional_data, is_digital, sku)
                 payload[:id] = product_id unless product_id.nil?
-                payload[:sku] = self.get_wrapper_sku(product)
+                payload[:sku] = sku
 
                 return payload
             end
@@ -76,7 +76,9 @@ module BigcommerceProductAgent
                 map = {}
 
                 product['model'].each do |model|
-                    map[model['sku']] = self.get_option(model)
+                    if model['isAvailableForPurchase']
+                      map[model['sku']] = self.get_option(model)
+                    end
                 end
 
                 return map


### PR DESCRIPTION
Update the upsert process to allow for deletion of products/variants

https://trello.com/c/p3fqs6ns/114-asbat-delete-products-in-acumen-and-have-them-automatically-deleted-in-bigcommerce