### PR TITLE
fix(bigcommerce_product_agent): Fix disambiguation process

### DIFF
--- a/lib/huginn_bigcommerce_product_agent/bigcommerce_product_agent.rb
+++ b/lib/huginn_bigcommerce_product_agent/bigcommerce_product_agent.rb
@@ -304,7 +304,7 @@ module Agents
         # page_title is the user-facing display value for product pages.
         if boolify(options['should_disambiguate'])
            payload[:page_title] = payload[:name]
-           payload[:name].concat(" |~ " + raw_product['sku'])
+           payload[:name] = payload[:name] + " |~ " + raw_product['sku']
         end
 
         if bc_product


### PR DESCRIPTION
Fix an error in the disambiguation logic that occasionally leads to incorrect page_title attribute

https://trello.com/c/yU9O24sB/385-usnbat-see-sku-in-the-page-title
https://trello.com/c/Y56oks7k/384-asbat-see-disambiguated-product-names