### PR TITLE
fix(bigcommerce_product_agent): fix syntax error

### DIFF
--- a/lib/huginn_bigcommerce_product_agent/bigcommerce_product_agent.rb
+++ b/lib/huginn_bigcommerce_product_agent/bigcommerce_product_agent.rb
@@ -258,7 +258,9 @@ module Agents
           'value': related_product_ids * ',' # concatenate as a CSV
         }
 
-        payload['custom_fields'].push(field) unless related_product_ids.empty?
+        unless related_product_ids.empty?
+          payload['custom_fields'].push(field)
+        end
 
         # return the finalized payload
         payload
@@ -274,6 +276,7 @@ module Agents
             product: result,
             status: 200,
           }
+        end
       rescue => e
         create_event payload: {
           status: 500,


### PR DESCRIPTION
Fix task failure caused by mising `end` in the `upsert_product` method

https://trello.com/c/kYrw0qwW/426-asbat-see-useful-errors-when-sync-processes-fail