### PR TITLE
fix(product_mapper): ensure the agent sets inventory level

### DIFF
--- a/lib/mapper/product_mapper.rb
+++ b/lib/mapper/product_mapper.rb
@@ -32,6 +32,13 @@ module BigcommerceProductAgent
                   width: product['width'] ? product['width']['value'] : '0',
                   inventory_tracking: isDigital || !track_inventory ? 'none' : 'product',
                 }
+
+                stock = get_additional_property_value(product, 'product_inventory', 0)
+
+                if (stock)
+                  result[:inventory_level] = stock
+                end
+
                 result[:upc] = product['isbn'] ? product['isbn'] : product['gtin12']
                 result[:gtin] = product['gtin12'] if product['gtin12']
 


### PR DESCRIPTION
Modify the agent so that it accurately sets product inventory in BigCommerce when there is inventory data available

https://trello.com/c/XQkoS13G/823-asbat-see-the-product-sync-set-inventory-levels-in-bigcommerce