### PR TITLE
fix(lib/*): prevent false low stock warnings

### DIFF
--- a/lib/client/product.rb
+++ b/lib/client/product.rb
@@ -94,7 +94,7 @@ module BigcommerceProductAgent
             end
 
             # When using sku:in you must specify the fields you want returned.
-            def get_by_skus(skus, include = %w[custom_fields modifiers], include_fields = %w[sku categories])
+            def get_by_skus(skus, include = %w[custom_fields modifiers], include_fields = %w[sku categories inventory_tracking])
                 products = []
                 skus.each do |sku|
                     begin

--- a/lib/huginn_bigcommerce_product_agent/bigcommerce_product_agent.rb
+++ b/lib/huginn_bigcommerce_product_agent/bigcommerce_product_agent.rb
@@ -347,7 +347,7 @@ module Agents
         if (track_inventory)
           track_inventory = boolify(raw_product['trackInventory'])
         end
-        bc_payload = get_mapper(:ProductMapper).map_payload(raw_product, additional_data, track_inventory)
+        bc_payload = get_mapper(:ProductMapper).map_payload(raw_product, bc_product, additional_data, track_inventory)
         bc_payload['id'] = bc_product['id'] unless bc_product.nil? || bc_product['id'].nil?
         # NOTE: bc_product will be nil when this is called with `to_create` products
 


### PR DESCRIPTION
Implement a workaround to prevent false positive low stock warnings for products with inventory tracking disabled

https://trello.com/c/e4e2jobl/827-asnbat-see-false-positive-low-stock-warnings-from-bigcommerce